### PR TITLE
[qbittorrent] add config file the correct way

### DIFF
--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -133,7 +133,7 @@ USER kah
 
 EXPOSE 6881 6881/udp ${WEBUI_PORT}
 
-COPY /qbittorrent/qBittorrent.conf /config/qBittorrent/qBittorrent.conf
+COPY /qbittorrent/qBittorrent.conf /app/qBittorrent.conf
 
 COPY ./qbittorrent/entrypoint.sh /entrypoint.sh
 CMD ["/entrypoint.sh"]

--- a/qbittorrent/entrypoint.sh
+++ b/qbittorrent/entrypoint.sh
@@ -4,4 +4,9 @@
 source "/shim/umask.sh"
 source "/shim/vpn.sh"
 
+if [[ ! -f "/config/qBittorrent/qBittorrent.conf" ]]; then
+    mkdir -p /config/qBittorrent
+    cp /app/qBittorrent.conf /config/qBittorrent/qBittorrent.conf
+fi
+
 exec /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" ${EXTRA_ARGS}


### PR DESCRIPTION
Copy the qb config into /app, then copy it on start if it doesn't exist to /config