### PR TITLE
[jackett] Add goss tests

### DIFF
--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build
+      - name: Build and push
         if: github.ref != 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
@@ -76,6 +76,19 @@ jobs:
           context: .
           file: ./${{ github.workflow }}/Dockerfile
           platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            k8sathome/pull-request:${{github.event.number}}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build local single-platform for testing
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v2
+        with:
+          build-args: VERSION=${{ steps.prep.outputs.version }}
+          context: .
+          file: ./${{ github.workflow }}/Dockerfile
           load: true
           tags: |
             k8sathome/pull-request:${{github.event.number}}
@@ -88,11 +101,6 @@ jobs:
           GOSS_FILE: ${{ github.workflow }}/goss.yaml
         run: |
           dgoss run k8sathome/pull-request:${{github.event.number}}
-
-      - name: Push image
-        if: github.ref != 'refs/heads/main'
-        run: |
-          docker push k8sathome/pull-request:${{github.event.number}}
 
       - name: Build and Push
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -49,7 +49,7 @@ jobs:
           driver-opts: image=moby/buildkit:master
 
       - name: Set up goss/dgoss
-        uses: e1himself/goss-installation-action
+        uses: e1himself/goss-installation-action@v1.0.3
         with:
           version: 'v0.3.16'
 

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -19,6 +19,7 @@ on:
 
 env:
   REGISTRY_IMAGE: k8sathome/${{ github.workflow }}
+  GOSS_SLEEP: 30
 
 jobs:
   build:
@@ -47,6 +48,11 @@ jobs:
           version: latest
           driver-opts: image=moby/buildkit:master
 
+      - name: Set up goss/dgoss
+        uses: e1himself/goss-installation-action
+        with:
+          version: 'v0.3.16'
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -64,6 +70,13 @@ jobs:
           push: true
           tags: |
             k8sathome/pull-request:${{github.event.number}}
+
+      - name: Test image
+        if: github.ref != 'refs/heads/main'
+        env:
+          GOSS_FILE: ${{ github.workflow }}/goss.yaml
+        run: |
+          dgoss run k8sathome/pull-request:${{github.event.number}}
 
       - name: Build and Push
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and Push
+      - name: Build
         if: github.ref != 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
@@ -76,7 +76,6 @@ jobs:
           context: .
           file: ./${{ github.workflow }}/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
           load: true
           tags: |
             k8sathome/pull-request:${{github.event.number}}
@@ -89,6 +88,11 @@ jobs:
           GOSS_FILE: ${{ github.workflow }}/goss.yaml
         run: |
           dgoss run k8sathome/pull-request:${{github.event.number}}
+
+      - name: Push image
+        if: github.ref != 'refs/heads/main'
+        run: |
+          docker push k8sathome/pull-request:${{github.event.number}}
 
       - name: Build and Push
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -19,6 +19,7 @@ on:
 
 env:
   REGISTRY_IMAGE: k8sathome/${{ github.workflow }}
+  # How long to sleep before running the tests (gives the application time to start)
   GOSS_SLEEP: 30
 
 jobs:
@@ -52,6 +53,14 @@ jobs:
         uses: e1himself/goss-installation-action@v1.0.3
         with:
           version: 'v0.3.16'
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -77,8 +77,11 @@ jobs:
           file: ./${{ github.workflow }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          load: true
           tags: |
             k8sathome/pull-request:${{github.event.number}}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Test image
         if: github.ref != 'refs/heads/main'

--- a/jackett/goss.yaml
+++ b/jackett/goss.yaml
@@ -1,0 +1,7 @@
+process:
+  jackett:
+    running: true
+
+port:
+  tcp6:9117:
+    listening: true


### PR DESCRIPTION
This PR adds [goss](https://github.com/aelsabbahy/goss) test support (including layer caching) for the Docker images we build.

The `Build local single-platform for testing` step is intended to limit the number of pulls we have to do from Docker Hub. Unfortunately the `docker/build-push-action` doesn't support multi-arch in combination with `load: true`, so we can't keep it all local :(

Why goss? I found a good article [here](https://blog.phonito.io/unit-testing-docker-images/). I used to run a whole Chef Inspec based workflow when I built my own images in Gitlab, but that was pretty heavy and slow. This is a nice lightweight solution. 

This could help maintain the quality of our images :-)

Potentially fixes #12 