### PR TITLE
[wireguard] Allow iptables backend selection

### DIFF
--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -4,6 +4,8 @@ ARG VERSION
 
 USER root
 
+COPY ./wireguard/build /build
+
 RUN \
   export EXTRA_INSTALL_ARG="build-essential git" \
   && apt-get -qq update \
@@ -21,17 +23,9 @@ RUN \
   && make -C src -j$(nproc) \
   && make -C src install \
   && sed -i "s:sysctl -q net.ipv4.conf.all.src_valid_mark=1:# skipping setting net.ipv4.conf.all.src_valid_mark:" /usr/bin/wg-quick \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables -F OUTPUT" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables -F OUTPUT" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables -A OUTPUT *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables -A OUTPUT *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/ip -4 route add *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/sbin/ip -6 route add *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/bin/wg show *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/bin/wg-quick up *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/bin/wg-quick down *" >> /etc/sudoers.d/kah \
-  && echo "kah ALL= EXEC: NOPASSWD: /usr/bin/find /etc/wireguard -type f *" >> /etc/sudoers.d/kah \
-  && echo 'Defaults env_keep +="TZ"' >> /etc/sudoers.d/kah \
+  && mv /build/sudoers_kah /etc/sudoers.d/kah \
+  && chown root:root /etc/sudoers.d/* \
+  && chmod 644 /etc/sudoers.d/* \
   && echo "UpdateMethod=docker\nPackageVersion=${VERSION}\nPackageAuthor=[Team k8s-at-home](https://github.com/k8s-at-home)" > /app/package_info \
   && apt-get remove -y ${EXTRA_INSTALL_ARG} \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
@@ -42,6 +36,7 @@ RUN \
     /tmp/* \
     /var/lib/apt/lists/* \
     /var/tmp/ \
+    /build \
   && chmod -R u=rwX,go=rX /app \
   && echo umask ${UMASK} >> /etc/bash.bashrc \
   && update-ca-certificates

--- a/wireguard/README.md
+++ b/wireguard/README.md
@@ -17,9 +17,10 @@ The container runs as a non-privileged user. This user should **not** be changed
 You will need a configuration file for your Wireguard interface. 
 Mount this configuration file to /etc/wireguard/ (e.g. `/etc/wireguard/wg0.conf`)
 
-| Environment variable | Description | Default value |
-| --- | --- | --- |
-| KILLSWITCH | Enable a killswitch that kills all trafic when the VPN is not connected | `false` |
-| KILLSWITCH_EXCLUDEDNETWORKS_IPV4 | A separated list of IPv4 networks that will be excluded from the VPN/killswitch |  |
-| KILLSWITCH_EXCLUDEDNETWORKS_IPV6 | A separatedlist of IPv6 networks that will be excluded from the VPN/killswitch |  |
-| SEPARATOR | The separator that is used to split the `KILLSWITCH_EXCLUDEDNETWORKS` lists | `;` |
+| Environment variable             | Description                                                                     | Default value |
+| -------------------------------- | ------------------------------------------------------------------------------- | ------------- |
+| IPTABLES_BACKEND                 | Override the backend used by iptables. Valid values are `nft` and `legacy`      |               |
+| KILLSWITCH                       | Enable a killswitch that kills all trafic when the VPN is not connected         | `false`       |
+| KILLSWITCH_EXCLUDEDNETWORKS_IPV4 | A separated list of IPv4 networks that will be excluded from the VPN/killswitch |               |
+| KILLSWITCH_EXCLUDEDNETWORKS_IPV6 | A separatedlist of IPv6 networks that will be excluded from the VPN/killswitch  |               |
+| SEPARATOR                        | The separator that is used to split the `KILLSWITCH_EXCLUDEDNETWORKS` lists     | `;`           |

--- a/wireguard/build/sudoers_kah
+++ b/wireguard/build/sudoers_kah
@@ -1,0 +1,17 @@
+kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables-legacy-save
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables-legacy-save
+kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables-nft-save
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables-nft-save
+kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables -F OUTPUT
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables -F OUTPUT
+kah ALL= EXEC: NOPASSWD: /usr/sbin/iptables -A OUTPUT *
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip6tables -A OUTPUT *
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip -4 route add *
+kah ALL= EXEC: NOPASSWD: /usr/sbin/ip -6 route add *
+kah ALL= EXEC: NOPASSWD: /usr/bin/wg show *
+kah ALL= EXEC: NOPASSWD: /usr/bin/wg-quick up *
+kah ALL= EXEC: NOPASSWD: /usr/bin/wg-quick down *
+kah ALL= EXEC: NOPASSWD: /usr/bin/find /etc/wireguard -type f *
+kah ALL= EXEC: NOPASSWD: /usr/bin/update-alternatives --set iptables *
+kah ALL= EXEC: NOPASSWD: /usr/bin/update-alternatives --set ip6tables *
+Defaults env_keep +="TZ"

--- a/wireguard/entrypoint.sh
+++ b/wireguard/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source "/shim/iptables-backend.sh"
+
 if [[ "$(cat /proc/sys/net/ipv4/conf/all/src_valid_mark)" != "1" ]]; then
     echo "[WARNING] sysctl net.ipv4.conf.all.src_valid_mark=1 is not set" >&2
 fi

--- a/wireguard/shim/iptables-backend.sh
+++ b/wireguard/shim/iptables-backend.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Original idea / source: https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/iptables-wrapper-installer.sh
+
+set -eu
+
+IPTABLES_BACKEND=${IPTABLES_BACKEND:-""}
+
+if [ -n "${IPTABLES_BACKEND}" ]; then
+    case "${IPTABLES_BACKEND}" in
+        nft|legacy)
+            mode="${IPTABLES_BACKEND}"
+            ;;
+        *)
+            echo "[ERROR] '${IPTABLES_BACKEND}' is not a valid value for IPTABLES_BACKEND. Please use either 'nft' or 'legacy'".
+            exit 1
+    esac
+else
+    # Detect whether the base system is using iptables-legacy or iptables-nft. 
+    # This assumes that some non-containerized process (eg kubelet) has already created some iptables rules.
+    # In case of doubt, it will always pick legacy mode.
+    num_legacy_lines=$( (sudo /usr/sbin/iptables-legacy-save || true; sudo /usr/sbin/ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+    num_nft_lines=$( (sudo /usr/sbin/iptables-nft-save || true; sudo /usr/sbin/ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+        mode=legacy
+    else
+        mode=nft
+    fi
+fi
+
+# Update links to point to the selected binaries
+sudo /usr/bin/update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null || failed=1
+sudo /usr/bin/update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null || failed=1
+
+if [ "${failed:-0}" = 1 ]; then
+    echo "[ERROR] Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    exit 1
+fi
+
+echo "[INFO] Running iptables in ${mode} mode"


### PR DESCRIPTION
This allows the backend to be set for `iptables`. This is useful when the host system is running iptables in nft mode instead of legacy mode, since otherwise the iptables rules cannot be set.

The script _tries_ to determine the correct backend automatically, and will default to legacy mode if it cannot determine the backend to use. By setting the `IPTABLES_BACKEND` env var, a user can override the backend that is used.