### PR TITLE
Allow builds on forks

### DIFF
--- a/.github/workflows/actions-runner.yaml
+++ b/.github/workflows/actions-runner.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/actions-runner.yaml
+++ b/.github/workflows/actions-runner.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/actions-runner.yaml
+++ b/.github/workflows/actions-runner.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/actions-runner.yaml
+++ b/.github/workflows/actions-runner.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/appdaemon.yaml
+++ b/.github/workflows/appdaemon.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/appdaemon.yaml
+++ b/.github/workflows/appdaemon.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/appdaemon.yaml
+++ b/.github/workflows/appdaemon.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/appdaemon.yaml
+++ b/.github/workflows/appdaemon.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/bazarr.yaml
+++ b/.github/workflows/bazarr.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/bazarr.yaml
+++ b/.github/workflows/bazarr.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/bazarr.yaml
+++ b/.github/workflows/bazarr.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/bazarr.yaml
+++ b/.github/workflows/bazarr.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/git-crypt.yaml
+++ b/.github/workflows/git-crypt.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/git-crypt.yaml
+++ b/.github/workflows/git-crypt.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/git-crypt.yaml
+++ b/.github/workflows/git-crypt.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/git-crypt.yaml
+++ b/.github/workflows/git-crypt.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -70,8 +70,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -104,8 +104,8 @@ jobs:
       run: |
         dgoss run k8sathome/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -51,6 +51,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -78,7 +79,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -71,7 +71,7 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -85,7 +85,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build local single-platform for testing
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -98,7 +98,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Test image
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -103,7 +103,7 @@ jobs:
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |
-        dgoss run k8sathome/pull-request:${{github.event.number}}
+        dgoss run ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push (non PR)
       if: github.event_name != 'pull_request'

--- a/.github/workflows/jackett.yaml
+++ b/.github/workflows/jackett.yaml
@@ -80,7 +80,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -93,7 +93,7 @@ jobs:
         file: ./${{ github.workflow }}/Dockerfile
         load: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -114,5 +114,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/lidarr.yaml
+++ b/.github/workflows/lidarr.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/lidarr.yaml
+++ b/.github/workflows/lidarr.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/lidarr.yaml
+++ b/.github/workflows/lidarr.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/lidarr.yaml
+++ b/.github/workflows/lidarr.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/network-ups-tools.yaml
+++ b/.github/workflows/network-ups-tools.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/network-ups-tools.yaml
+++ b/.github/workflows/network-ups-tools.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/network-ups-tools.yaml
+++ b/.github/workflows/network-ups-tools.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/network-ups-tools.yaml
+++ b/.github/workflows/network-ups-tools.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/nzbget.yaml
+++ b/.github/workflows/nzbget.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbget.yaml
+++ b/.github/workflows/nzbget.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbget.yaml
+++ b/.github/workflows/nzbget.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbget.yaml
+++ b/.github/workflows/nzbget.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/nzbhydra2.yaml
+++ b/.github/workflows/nzbhydra2.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbhydra2.yaml
+++ b/.github/workflows/nzbhydra2.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbhydra2.yaml
+++ b/.github/workflows/nzbhydra2.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/nzbhydra2.yaml
+++ b/.github/workflows/nzbhydra2.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/plex-media-server.yaml
+++ b/.github/workflows/plex-media-server.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/plex-media-server.yaml
+++ b/.github/workflows/plex-media-server.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/plex-media-server.yaml
+++ b/.github/workflows/plex-media-server.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/plex-media-server.yaml
+++ b/.github/workflows/plex-media-server.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/qbittorrent.yaml
+++ b/.github/workflows/qbittorrent.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/qbittorrent.yaml
+++ b/.github/workflows/qbittorrent.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/qbittorrent.yaml
+++ b/.github/workflows/qbittorrent.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/qbittorrent.yaml
+++ b/.github/workflows/qbittorrent.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/radarr.yaml
+++ b/.github/workflows/radarr.yaml
@@ -80,7 +80,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -93,7 +93,7 @@ jobs:
         file: ./${{ github.workflow }}/Dockerfile
         load: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -102,7 +102,7 @@ jobs:
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |
-        dgoss run ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+        dgoss run ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -114,5 +114,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/radarr.yaml
+++ b/.github/workflows/radarr.yaml
@@ -51,6 +51,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -78,7 +79,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/radarr.yaml
+++ b/.github/workflows/radarr.yaml
@@ -71,7 +71,7 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -85,7 +85,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build local single-platform for testing
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -98,7 +98,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Test image
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |

--- a/.github/workflows/radarr.yaml
+++ b/.github/workflows/radarr.yaml
@@ -70,8 +70,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -104,8 +104,8 @@ jobs:
       run: |
         dgoss run ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/sabnzbd.yaml
+++ b/.github/workflows/sabnzbd.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/sabnzbd.yaml
+++ b/.github/workflows/sabnzbd.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/sabnzbd.yaml
+++ b/.github/workflows/sabnzbd.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/sabnzbd.yaml
+++ b/.github/workflows/sabnzbd.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/sonarr.yaml
+++ b/.github/workflows/sonarr.yaml
@@ -80,7 +80,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -93,7 +93,7 @@ jobs:
         file: ./${{ github.workflow }}/Dockerfile
         load: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -102,7 +102,7 @@ jobs:
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |
-        dgoss run ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+        dgoss run ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -114,5 +114,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/sonarr.yaml
+++ b/.github/workflows/sonarr.yaml
@@ -51,6 +51,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -78,7 +79,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/sonarr.yaml
+++ b/.github/workflows/sonarr.yaml
@@ -71,7 +71,7 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -85,7 +85,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build local single-platform for testing
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -98,7 +98,7 @@ jobs:
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Test image
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       env:
         GOSS_FILE: ${{ github.workflow }}/goss.yaml
       run: |

--- a/.github/workflows/sonarr.yaml
+++ b/.github/workflows/sonarr.yaml
@@ -70,8 +70,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -104,8 +104,8 @@ jobs:
       run: |
         dgoss run ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/tautulli.yaml
+++ b/.github/workflows/tautulli.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/tautulli.yaml
+++ b/.github/workflows/tautulli.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/tautulli.yaml
+++ b/.github/workflows/tautulli.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/tautulli.yaml
+++ b/.github/workflows/tautulli.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:${{ steps.prep.outputs.version }}

--- a/.github/workflows/wireguard.yaml
+++ b/.github/workflows/wireguard.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/wireguard.yaml
+++ b/.github/workflows/wireguard.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/wireguard.yaml
+++ b/.github/workflows/wireguard.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/wireguard.yaml
+++ b/.github/workflows/wireguard.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/xteve.yaml
+++ b/.github/workflows/xteve.yaml
@@ -56,7 +56,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/xteve.yaml
+++ b/.github/workflows/xteve.yaml
@@ -55,8 +55,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -67,8 +67,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/xteve.yaml
+++ b/.github/workflows/xteve.yaml
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -77,5 +77,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/xteve.yaml
+++ b/.github/workflows/xteve.yaml
@@ -49,6 +49,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/zenbot.yaml
+++ b/.github/workflows/zenbot.yaml
@@ -55,7 +55,7 @@ jobs:
         password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build and Push
-      if: github.ref != 'refs/heads/main'
+      if: github.event.number != ''
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}

--- a/.github/workflows/zenbot.yaml
+++ b/.github/workflows/zenbot.yaml
@@ -48,6 +48,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -62,7 +63,7 @@ jobs:
         context: .
         file: ./${{ github.workflow }}/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: false # GitHub secrets not available in PRs
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 

--- a/.github/workflows/zenbot.yaml
+++ b/.github/workflows/zenbot.yaml
@@ -64,7 +64,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/pull-request:${{github.event.number}}
+          ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
     - name: Build and Push
       if: github.ref == 'refs/heads/main'
@@ -76,5 +76,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:latest
-          ghcr.io/k8s-at-home/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:latest
+          ghcr.io/${{ github.repository_owner }}/${{ env.REGISTRY_IMAGE }}:v${{ steps.prep.outputs.version }}

--- a/.github/workflows/zenbot.yaml
+++ b/.github/workflows/zenbot.yaml
@@ -54,8 +54,8 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Build and Push
-      if: github.event.number != ''
+    - name: Build and Push (PR)
+      if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}
@@ -66,8 +66,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/pull-request:${{github.event.number}}
 
-    - name: Build and Push
-      if: github.ref == 'refs/heads/main'
+    - name: Build and Push (non PR)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2
       with:
         build-args: VERSION=${{ steps.prep.outputs.version }}


### PR DESCRIPTION
This PR makes actions on forks work.

This is useful to allow testing a new image locally before submitting into the community main repository.