### PR TITLE
Disable failfast on build workflow to prevent blocking unrelated builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: [detect_changes]
     strategy:
       matrix: ${{fromJson(needs.detect_changes.outputs.matrix)}}
-      fail-fast: true
+      fail-fast: false
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"
     steps:
     - name: Checkout


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->
**Description of the change**
<!-- Describe the scope of your change - i.e. what the change does. -->

Currently all builds get cancelled if one fails. This is not correct behavior as builds are not related to eachother.
This PR disables this behavior, it should(tm) make sure other builds still continue regardless of build failure of other builds.


**Benefits**

<!-- What benefits will be realized by the code change? -->

Not missing updates due to unrelated builds failing for example

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

Not really any.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
