### PR TITLE
Re-Push if base has been updated

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -18,6 +18,23 @@ jobs:
       with:
         token: ${{ secrets.PAT }}
         fetch-depth: 1
+    - name: Fetch base versions
+      run: |
+        find . -maxdepth 1 -mindepth 1 -type d | while read app; do
+          if test -f "./${app}/latest-base.sh"; then
+            base=$(bash "./${app}/latest-base.sh")
+            if [[ ! -z "${base}" || "${base}" != "null" ]]; then
+              echo "${base}" | tee "${app}/BASE" > /dev/null
+              echo "${app} ${base}"
+            fi
+          else
+            base=$(cat "./ubuntu/VERSION")
+            if [[ ! -z "${base}" || "${base}" != "null" ]]; then
+              echo "${base}" | tee "${app}/BASE" > /dev/null
+              echo "${app} ${base}"
+            fi
+          fi
+        done
     - name: Fetch release versions
       run: |
         find . -maxdepth 1 -mindepth 1 -type d | while read app; do


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This is a rather simple PR that keeps track of the base version used for each container, which by default defaults to ubuntu
It forces a repush (if the tests pass) as soon the base version changes, by keeping track of the base version with the container.


**Benefits**

<!-- What benefits will be realized by the code change? -->

It won't have much effect for the applications, but might provide a small security improvements for applications that aren't frequently updated

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

This would case multiple versions (hashes) of the same tag circulating

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

With:
VERSION
PLATFORM
and now:
BASE

We might want to start looking at using YAML for these in the future. However for now this "just works" (tm)