### PR TITLE
Don't error on cache-move and don't cache base

### DIFF
--- a/.github/workflows/apps.yaml
+++ b/.github/workflows/apps.yaml
@@ -129,7 +129,7 @@ jobs:
       if: ${{ steps.prep.outputs.goss == 'true' }}
       run: |
         rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache | exit 0
 
 
     # Run GOSS tests if included with the container

--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -105,12 +105,3 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}:latest
           ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}:${{ steps.prep.outputs.version }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
-    # Temporary fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR fixes 2 small issues with the current temporary cache workaround:
1. Don't error if there is no cache to move. For example: This happens when there is no goss test.
2. Don't use cache for base build, because we don't run any tests there so there is nothing to cache and no cache to use.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
(cherry picked from commit 704cbfc2c468f551ec208ba4462248c22f096608)
