### PR TITLE
Added latest-version.sh to alpine

### DIFF
--- a/base/alpine/latest-version.sh
+++ b/base/alpine/latest-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+version=$(curl -s "https://registry.hub.docker.com/v1/repositories/library/alpine/tags" | jq --raw-output '.[] | select(.name | contains(".")) | .name' | sort -t "." -k1,1n -k2,2n -k3,3n | tail -n1)
+version="${version#*v}"
+version="${version#*release-}"
+printf "%s" "${version}"


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

**Description of the change**

I added the latest-version.sh script to the Alpine base image. I don't know if the current repo version of 3.12 is being used for a particular reason because 3.13.2 is the current version on Docker hub. The script currently gets a semver of X.X.X. Perhaps it should just be X.X

**Benefits**

Automates the updating of the Alpine version.

**Possible drawbacks**

Could break gh actions or go against the reason why 3.12 is currently being used by k8s@home.

**Applicable issues**

N/A

**Additional information**

N/A
