### PR TITLE
[reg] Removed CMD to get entrypoint to work correctly

### DIFF
--- a/apps/reg/Dockerfile
+++ b/apps/reg/Dockerfile
@@ -4,7 +4,6 @@ FROM ghcr.io/k8s-at-home/ubuntu:latest
 ARG VERSION
 ARG TARGETPLATFORM
 USER root
-
 WORKDIR /app
 
 # hadolint ignore=DL3008,DL3015,SC2086
@@ -41,4 +40,3 @@ WORKDIR /config
 COPY ./apps/reg/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["--help"]

--- a/apps/reg/entrypoint.sh
+++ b/apps/reg/entrypoint.sh
@@ -4,4 +4,4 @@
 source "/shim/umask.sh"
 source "/shim/vpn.sh"
 
-exec /app/reg "${@}" "${EXTRA_ARGS}"
+exec /app/reg ${@} ${EXTRA_ARGS}


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

**Description of the change**

Fixes entrypoint issue where CMD was passing the --help parameter and quotes around variables didn't allow reg to run correctly.

**Benefits**

Allows you to run $EXTRA_ARGS from chart.

**Possible drawbacks**

None.

**Applicable issues**

None

**Additional information**

None
