### PR TITLE
Fix new containers failing CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
         fi
         if [ "${{github.event_name}}" == "pull_request" ]; then
           echo ::set-output name=push::false
-          echo ::set-output name=cache_from::"type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}:buildcache"
+          echo ::set-output name=cache_from::"type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}:buildcache" || echo ::set-output name=cache_from::""
           echo ::set-output name=cache_to::""
         else
           echo ::set-output name=push::true


### PR DESCRIPTION
**Description of the change**

Falls back to not using from builstorage when it errors

**Benefits**

New containers currently fail CI because there is no container registered on the repo yet.

**Possible drawbacks**

We need to manually keep an eye if the buildstorage keeps working, because it won't throw us an error anymore.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
