### PR TITLE
Make sure both /app and /config are owned by 568 in the base image an…

### DIFF
--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -24,6 +24,7 @@ RUN \
   && \
   mkdir -p /config \
   && chown -R kah:kah /config
+  && chmod -R 775 /config
 
 WORKDIR /app
 
@@ -63,6 +64,7 @@ RUN \
   && ln -s /usr/local/bin/micro /usr/local/bin/emacs \
   && unset MICRO_ARCH \
   && unset MICRO_VERSION \
+  && chown -R kah:kah /app
   && \
   printf "/bin/bash /shim/greeting.sh\n" >> /etc/bash.bashrc \
   && \

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   --no-create-home \
   && \
   mkdir -p /config \
-  && chown -R kah:kah /config
+  && chown -R kah:kah /config \
   && chmod -R 775 /config
 
 WORKDIR /app
@@ -64,7 +64,7 @@ RUN \
   && ln -s /usr/local/bin/micro /usr/local/bin/emacs \
   && unset MICRO_ARCH \
   && unset MICRO_VERSION \
-  && chown -R kah:kah /app
+  && chown -R kah:kah /app \
   && \
   printf "/bin/bash /shim/greeting.sh\n" >> /etc/bash.bashrc \
   && \


### PR DESCRIPTION
**Description of the change**

This is a relatively easy fix, that adds the following to the ubuntu base charts:
- Taking Ownership of the /app directory with kah:kah
- Give group write (chmod 775) to the kah group

**Benefits**

There are/might be some edge cases where this might be relevant for some apps.
It's also just simply cleaner to specifically mention which permissions are set when these folders are created.

**Possible drawbacks**

None that I'm aware off.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
