### PR TITLE
Example permissions fix

### DIFF
--- a/apps/jackett/Dockerfile
+++ b/apps/jackett/Dockerfile
@@ -46,7 +46,7 @@ RUN \
   && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc \
   && update-ca-certificates
 
-# You can specify your own user and group, while retaining write-access to /config, by setting:
+# You can specify your own user and group, while retaining all specified permissions, by setting:
 # securityContext.supplementalGroup[568]
 USER kah
 

--- a/apps/jackett/Dockerfile
+++ b/apps/jackett/Dockerfile
@@ -47,7 +47,7 @@ RUN \
   && update-ca-certificates
 
 # You can specify your own user and group, while retaining all specified permissions, by setting:
-# securityContext.supplementalGroup[568]
+# securityContext.supplementalGroup: [568]
 USER kah
 
 EXPOSE 9117

--- a/apps/jackett/Dockerfile
+++ b/apps/jackett/Dockerfile
@@ -41,10 +41,13 @@ RUN \
     /tmp/* \
     /var/lib/apt/lists/* \
     /var/tmp/ \
+  && chown -R kah:kah /app \
   && chmod -R u=rwX,go=rX /app \
   && printf "umask %d" "${UMASK}" >> /etc/bash.bashrc \
   && update-ca-certificates
 
+# You can specify your own user and group, while retaining write-access to /config, by setting:
+# securityContext.supplementalGroup[568]
 USER kah
 
 EXPOSE 9117


### PR DESCRIPTION
**Description of the change**

This is a small fix, that gives an example how to enforce uniform permissions on the containers:
- It gives the kah:kah user ownership of both /app and /config (because it's technically their owner anyway)
- It gives the kah group specific write permissions on /config
- It adds a hint how to use your own groups, while retaining all these permissions on k8s

**Benefits**

Some Apps might have a problem by the unstable way how docker handles ownership while creating the containers.
This is in contrast with the goal of these containers to be (relatively) uniform in style.

**Possible drawbacks**

If users currently can run with the 568 user, they still can
if users still can run with another user, they still should be able to.

Technically, I do not see anything that would break.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
