### PR TITLE
[coredns] Fix k8s_gateway load order

### DIFF
--- a/apps/coredns/plugin.cfg
+++ b/apps/coredns/plugin.cfg
@@ -54,6 +54,7 @@ azure:azure
 clouddns:clouddns
 k8s_external:k8s_external
 kubernetes:kubernetes
+k8s_gateway:github.com/ori-edge/k8s_gateway
 file:file
 auto:auto
 secondary:secondary
@@ -69,4 +70,3 @@ mdns:github.com/openshift/coredns-mdns
 alternate:github.com/coredns/alternate
 wgsd:github.com/jwhited/wgsd
 git:github.com/miekg/coredns-git
-k8s_gateway:github.com/ori-edge/k8s_gateway


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This change hoists the k8s_gateway plugin to the same level as the built-in CoreDNS kubernetes plugins as recommended by the instructions [here](https://github.com/ori-edge/k8s_gateway#with-compile-time-configuration-file).

**Benefits**

This allows using plugins that don't support fall through (namely `forward`) in the same server block as k8s_gateway.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
