### PR TITLE
Copy extra/lib/* to the /app dir

### DIFF
--- a/apps/emby/Dockerfile
+++ b/apps/emby/Dockerfile
@@ -64,6 +64,7 @@ RUN \
     /app \
     /tmp/opt/emby-server/system/* \
     /tmp/opt/emby-server/lib/* \
+    /tmp/opt/emby-server/extra/lib/* \
     /tmp/opt/emby-server/bin/ff* \
     /tmp/opt/emby-server/etc
 


### PR DESCRIPTION
This directory in the RPM contains libraries such as libva and libdrm which are required for Emby's included ffmpeg. Without this, transcoding doesn't work, which breaks playback of file formats not directly supported in the browser or client.