### PR TITLE
Make wireguard killswitch work even if excluded networks not specified

### DIFF
--- a/apps/wireguard/shim/killswitch.sh
+++ b/apps/wireguard/shim/killswitch.sh
@@ -24,9 +24,9 @@ then
             sudo /usr/sbin/ip -4 route add "${entry}" via "${DEFAULTROUTE_IPV4}" || echo "[WARNING] Received non-zero exit code adding route ${entry} via ${DEFAULTROUTE_IPV4}"
             sudo /usr/sbin/iptables -A OUTPUT -d "${entry}" -j ACCEPT || echo "[WARNING] Received non-zero exit code adding iptables rule to ACCEPT ${entry}"
         done
-
-        sudo /usr/sbin/iptables -A OUTPUT ! -o "${INTERFACE}" -m mark ! --mark $(sudo /usr/bin/wg show "${INTERFACE}" fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
     fi
+
+    sudo /usr/sbin/iptables -A OUTPUT ! -o "${INTERFACE}" -m mark ! --mark $(sudo /usr/bin/wg show "${INTERFACE}" fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
 
     # IPv6 killswitch
     DEFAULTROUTE_IPV6=$(/usr/sbin/ip -6 route | grep default | awk '{print $3}')
@@ -43,6 +43,7 @@ then
             sudo /usr/sbin/ip6tables -A OUTPUT -d "${entry}" -j ACCEPT || echo "[WARNING] Received non-zero exit code adding iptables rule to ACCEPT ${entry}"
         done
 
-        sudo /usr/sbin/ip6tables -A OUTPUT ! -o "${INTERFACE}" -m mark ! --mark $(sudo /usr/bin/wg show "${INTERFACE}" fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
     fi
+
+    sudo /usr/sbin/ip6tables -A OUTPUT ! -o "${INTERFACE}" -m mark ! --mark $(sudo /usr/bin/wg show "${INTERFACE}" fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
 fi


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Right now, due to the `-n` checks on lines 18 and 36, the wireguard killswitch does not work unless `KILLSWITCH_EXCLUDEDNETWORKS_IPV4` or `KILLSWITCH_EXCLUDEDNETWORKS_IPV6` are specified because the `REJECT` rule is not added, as far as I can tell.

**Benefits**

I had to specify `KILLSWITCH_EXCLUDEDNETWORKS_IPV4: "10.42.0.0/16"` to make it work for my cluster, but that results in:
```
wireguard [INFO] Excluding 10.42.0.0/16 from VPN IPv4 traffic
wireguard RTNETLINK answers: File exists
wireguard [WARNING] Received non-zero exit code adding route 10.42.0.0/16 via 10.42.0.1
```
I think this PR should make that unnecessary.

**Possible drawbacks**

Is it possible that it would break network access in some cases?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

Let me know if this is the wrong approach, and I'm using the killswitch incorrectly.
