### PR TITLE
Add dnsutils to kubectl

### DIFF
--- a/apps/kubectl/Dockerfile
+++ b/apps/kubectl/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     bash \
     ca-certificates \
     curl \
+    dnsutils \
     jq \
     tzdata \
   && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl" \


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds dnsutils to the container

**Benefits**

The ability to use utilities like dig

**Possible drawbacks**

Not being forced into using whatever ubuntu is pushing these days for dns utilities

**Applicable issues**

N/A

**Additional information**

This is not necessarily important, but it would allow me to use dig in my ddns script and avoid extra typing down the road as I build on it.
