### PR TITLE
Add support for Flood for Transmission

### DIFF
--- a/apps/transmission/Dockerfile
+++ b/apps/transmission/Dockerfile
@@ -47,9 +47,6 @@ RUN \
 # hadolint ignore=DL3007
 FROM ghcr.io/k8s-at-home/ubuntu:latest
 
-ARG TARGETPLATFORM
-ARG VERSION
-
 # Proper way to set config directory
 ENV HOME=/config \
     XDG_CONFIG_HOME=/config \
@@ -61,6 +58,11 @@ USER root
 
 COPY --from=builder /usr/local/bin/transmission-daemon /app/transmission-daemon
 COPY --from=builder /usr/local/share/transmission/web /web
+
+# Install custom UI's
+RUN \
+  curl -o /tmp/flood-for-transmission.tar.gz -L "https://github.com/johman10/flood-for-transmission/releases/download/latest/flood-for-transmission.tar.gz" \
+  && tar xf /tmp/flood-for-transmission.tar.gz -C /
 
 # hadolint ignore=DL3008,DL3015
 RUN \


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

These changes allow to run [Flood for Transmission ](https://github.com/johman10/flood-for-transmission) within the docker container. This can be done by using the following command:
`docker run -e "TRANSMISSION_WEB_HOME=/flood-for-transmission" -p 9091:9091 transmission`

The default behaviour hasn't changed in any way.

**Benefits**

More beautiful UI for everyone

**Possible drawbacks**

Bigger container size (though little)
Complexity (though little)

**Applicable issues**

- fixes https://github.com/johman10/flood-for-transmission/issues/383

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
I'm the creator of Flood for Transmission. If you have any questions, let me know.