### PR TITLE
add support for NUT env var MODE, enable netclient

### DIFF
--- a/apps/network-ups-tools/Dockerfile
+++ b/apps/network-ups-tools/Dockerfile
@@ -6,7 +6,7 @@ USER root
 RUN \
   apt-get -qq update \
   && apt-get -qq install -y --no-install-recommends \
-    nut-server \
+    nut \
   && apt-get clean \
   && rm -rf \
     /tmp/* \

--- a/apps/network-ups-tools/entrypoint.sh
+++ b/apps/network-ups-tools/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-/sbin/upsdrvctl -u root start
-exec /sbin/upsd -u root -D
+# if one child dies, clean up the other(s)
+trap 'trap " " SIGTERM; kill 0; wait' SIGTERM SIGQUIT SIGINT
+
+if [[ "$MODE" =~ standalone|netserver ]] ; then
+  /sbin/upsdrvctl -u root start
+fi
+
+# these will run or not based on $MODE
+/sbin/upsd -u root -D &
+/sbin/upsmon -D &
+
+wait


### PR DESCRIPTION
**Description of the change**

- modify Dockerfile to install the 'nut' meta package (includes nut-client, nut-server)
- modify entrypoint to optionally start one or both of upsd or upsmon, depending on $MODE.

**Benefits**

this mirrors the behaviour of a local install and allows for running in 
netclient mode and monitoring a remote node that manages the connected UPS.

this can be controlled by configuring /etc/nut/nut.conf, as in a local
install, or overriding the MODE env var

**Possible drawbacks**

as the PR stands the default behaviour has changed to match the package default of 'none'.
we could change this in the Dockerfile to be 'standalone', which is the closest to the original behaviour.

**Applicable issues**

- https://github.com/k8s-at-home/container-images/pull/36

**Additional information**

https://github.com/networkupstools/nut/blob/master/conf/nut.conf.sample
